### PR TITLE
pickles2/px-fw-2.x@2.0.29 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ px2proj.get_actors('/sample_pages/role.html', function(actors){
 /**
  * get home directory path
  */
-px2proj.get_path_homedir(function(value){
+px2proj.get_realpath_homedir(function(value){
 	console.log(value);
 })
 
@@ -227,7 +227,7 @@ px2proj.get_path_controot(function(value){
 /**
  * DOCUMENT_ROOT のパスを取得する
  */
-px2proj.get_path_docroot(function(value){
+px2proj.get_realpath_docroot(function(value){
 	console.log(value);
 });
 
@@ -407,9 +407,11 @@ $ npm run documentation
 
 ### px2agent 2.0.5 (2016年??月??日)
 
-- pickles2/px-fw-2.x@2.0.23 対応
+- pickles2/px-fw-2.x@2.0.29 対応
 - `pj.publish()` に `keep_cache` オプションを追加。
 - `pj.publish()` に `paths_region` オプションを追加。
+- `pj.get_path_homedir()` を `pj.get_realpath_homedir()` に改名。(古いメソッド名の実装は残されているが非推奨)
+- `pj.get_path_docroot()` を `pj.get_realpath_docroot()` に改名。(古いメソッド名の実装は残されているが非推奨)
 
 ### px2agent 2.0.4 (2016年2月22日)
 

--- a/libs/px2project.js
+++ b/libs/px2project.js
@@ -292,9 +292,18 @@ module.exports = function(px2agent, php_self, options){
 	}
 
 	/**
-	 * get home directory path
+	 * get home directory path (deprecated)
+	 *
+	 * `get_path_homedir()` は 非推奨のメソッドです。
+	 * 代わりに、 `get_realpath_homedir()` を使用してください。
 	 */
 	this.get_path_homedir = function(cb){
+		return apiGet('api.get.path_homedir', '/', {}, cb);
+	}
+	/**
+	 * get home directory path
+	 */
+	this.get_realpath_homedir = function(cb){
 		return apiGet('api.get.path_homedir', '/', {}, cb);
 	}
 
@@ -306,9 +315,19 @@ module.exports = function(px2agent, php_self, options){
 	}
 
 	/**
-	 * DOCUMENT_ROOT のパスを取得する
+	 * DOCUMENT_ROOT のパスを取得する (deprecated)
+	 *
+	 * `get_path_docroot()` は 非推奨のメソッドです。
+	 * 代わりに、 `get_realpath_docroot()` を使用してください。
 	 */
 	this.get_path_docroot = function(cb){
+		return apiGet('api.get.path_docroot', '/', {}, cb);
+	}
+
+	/**
+	 * DOCUMENT_ROOT のパスを取得する
+	 */
+	this.get_realpath_docroot = function(cb){
 		return apiGet('api.get.path_docroot', '/', {}, cb);
 	}
 

--- a/tests/defaultTest.js
+++ b/tests/defaultTest.js
@@ -555,7 +555,7 @@ describe('ホームディレクトリのパスを取得する', function() {
 
 	it("ホームディレクトリのパスを取得する", function(done) {
 		this.timeout(60*1000);
-		pj.get_path_homedir( function( path_home_dir ){
+		pj.get_realpath_homedir( function( path_home_dir ){
 			// console.log(path_home_dir);
 			assert.equal( typeof(path_home_dir), typeof('') );
 			assert.equal( fs.realpathSync(path_home_dir), fs.realpathSync(__dirname+'/testData/htdocs1/px-files/') );
@@ -584,7 +584,7 @@ describe('ドキュメントルートディレクトリのパスを取得する'
 
 	it("ドキュメントルートディレクトリのパスを取得する", function(done) {
 		this.timeout(60*1000);
-		pj.get_path_docroot( function( path_docroot ){
+		pj.get_realpath_docroot( function( path_docroot ){
 			// console.log(path_docroot);
 			assert.equal( typeof(path_docroot), typeof('') );
 			assert.equal( fs.realpathSync(path_docroot), fs.realpathSync(__dirname+'/testData/htdocs1/') );
@@ -1191,7 +1191,7 @@ describe('PHPを異常終了させるテスト', function() {
 				});
 			}); })
 			.then(function(){ return new Promise(function(rlv, rjc){
-				pj.get_path_homedir(function(value, code, err){
+				pj.get_realpath_homedir(function(value, code, err){
 					assert.strictEqual( value, false );
 					assert.equal( childProcRtnCode, code );
 					assert.equal( typeof(''), typeof(err) );
@@ -1207,7 +1207,7 @@ describe('PHPを異常終了させるテスト', function() {
 				});
 			}); })
 			.then(function(){ return new Promise(function(rlv, rjc){
-				pj.get_path_docroot(function(value, code, err){
+				pj.get_realpath_docroot(function(value, code, err){
 					assert.strictEqual( value, false );
 					assert.equal( childProcRtnCode, code );
 					assert.equal( typeof(''), typeof(err) );


### PR DESCRIPTION
- `pj.get_path_homedir()` を `pj.get_realpath_homedir()` に改名。(古いメソッド名の実装は残されているが非推奨)
- `pj.get_path_docroot()` を `pj.get_realpath_docroot()` に改名。(古いメソッド名の実装は残されているが非推奨)